### PR TITLE
Fix dependency imports not to be relative

### DIFF
--- a/google-map-directions.js
+++ b/google-map-directions.js
@@ -1,5 +1,5 @@
-import { Polymer } from '../../@polymer/polymer/lib/legacy/polymer-fn.js';
-import { html } from '../../@polymer/polymer/lib/utils/html-tag.js';
+import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
 /* Copyright (c) 2015 Google Inc. All rights reserved. */
 /*

--- a/google-map-marker.js
+++ b/google-map-marker.js
@@ -1,5 +1,5 @@
-import { Polymer } from '../../@polymer/polymer/lib/legacy/polymer-fn.js';
-import { html } from '../../@polymer/polymer/lib/utils/html-tag.js';
+import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
 function setupDragHandler_() {
   if (this.draggable) {

--- a/google-map-point.js
+++ b/google-map-point.js
@@ -1,4 +1,4 @@
-import { Polymer } from '../../@polymer/polymer/lib/legacy/polymer-fn.js';
+import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 /* Copyright (c) 2015 Google Inc. All rights reserved. */
 /*
 The `google-map-point` element represents a point on a map. It's used as a child of other

--- a/google-map-poly.js
+++ b/google-map-poly.js
@@ -1,5 +1,5 @@
-import { Polymer } from '../../@polymer/polymer/lib/legacy/polymer-fn.js';
-import { html } from '../../@polymer/polymer/lib/utils/html-tag.js';
+import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import './google-map-point.js';
 
 Polymer({

--- a/google-map-search.js
+++ b/google-map-search.js
@@ -1,4 +1,4 @@
-import { Polymer } from '../../@polymer/polymer/lib/legacy/polymer-fn.js';
+import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 /* Copyright (c) 2015 Google Inc. All rights reserved. */
 /*
 `google-map-search` provides Google Maps Places API functionality.

--- a/google-map.js
+++ b/google-map.js
@@ -1,8 +1,8 @@
-import { Polymer } from '../../@polymer/polymer/lib/legacy/polymer-fn.js';
-import { html } from '../../@polymer/polymer/lib/utils/html-tag.js';
-import { IronResizableBehavior } from '../../@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
+import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
 import './google-map-marker.js';
-import '../../@johnriv/google-apis/google-maps-api.js';
+import '@johnriv/google-apis/google-maps-api.js';
 import { MarkerClusterer } from "@googlemaps/markerclusterer";
 
 /* Copyright (c) 2015 Google Inc. All rights reserved. */


### PR DESCRIPTION
Having them as relative is confusing some tool in the Vaadin tool chain and it the user ends up loading Polymer dependencies twice
