### PR TITLE
Pin library version to 3.57 

### DIFF
--- a/google-map.js
+++ b/google-map.js
@@ -290,10 +290,13 @@ Polymer({
 
     /**
      * Version of the Google Maps API to use.
+     * 
+     * DEC-2024: use version 3.57 to avoid conflict with new styling model 
+     * See https://developers.google.com/maps/new-map-style-opt-in#opt-out
      */
     version: {
       type: String,
-      value: '3.exp',
+      value: '3.57',
     },
 
     /**


### PR DESCRIPTION
This is necessary for issue https://github.com/FlowingCode/GoogleMapsAddon/issues/146.

![image](https://github.com/user-attachments/assets/6a3db020-86b2-4b58-96ad-6388a6d8bd92)

The [ongoing style changes on the library](https://developers.google.com/maps/new-map-style-opt-in) made the component not to display the map correctly as shown in the image. As [documentation mentions](https://developers.google.com/maps/new-map-style-opt-in#opt-out), we should use API version 3.57 to opt-out of the changes for the moment. 