### PR TITLE
Updates to fix GoogleMapsAddon#152

### DIFF
--- a/google-map.js
+++ b/google-map.js
@@ -90,7 +90,7 @@ Polymer({
       <slot id="markers" name="markers"></slot>
     </iron-selector>
 
-    <slot id="objects"></slot>
+    <slot id="objects" name="objects"></slot>
 `,
 
   is: 'google-map',

--- a/google-map.js
+++ b/google-map.js
@@ -386,8 +386,8 @@ Polymer({
      * For style documentation see https://developers.google.com/maps/documentation/javascript/reference#MapTypeStyle
      */
     styles: {
-      type: Object,
-      value() { return {}; },
+      type: Array,
+      value() { return []; },
     },
 
     /**

--- a/google-map.js
+++ b/google-map.js
@@ -291,12 +291,13 @@ Polymer({
     /**
      * Version of the Google Maps API to use.
      * 
-     * DEC-2024: use version 3.57 to avoid conflict with new styling model 
-     * See https://developers.google.com/maps/new-map-style-opt-in#opt-out
+     * 30-MAY-2025: change to current latest version 3.61.2 as 3.57 is a retired version 
+     * See https://developers.google.com/maps/documentation/javascript/versions#version-updates
+     * See release notes https://developers.google.com/maps/documentation/javascript/releases
      */
     version: {
       type: String,
-      value: '3.57',
+      value: '3.61.2',
     },
 
     /**


### PR DESCRIPTION
This PR includes: 

1- Update Maps API version from 3.57 (deprecated) to latest 3.61.2 ([latest release](https://developers.google.com/maps/documentation/javascript/releases)), as 3.57 is a retired version. This change ensures compatibility with current and future Google Maps releases. (This was mentioned on [GoogleMapsAddon#153](https://github.com/FlowingCode/GoogleMapsAddon/issues/153)).

![google maps version warning](https://github.com/user-attachments/assets/9332ce38-5bdc-4081-b8b3-aa3daa80b2d8)

2 - Fix console error of map styles property expected type.

![google maps styles error](https://github.com/user-attachments/assets/d3cf958e-3d43-4927-b50d-72876bc25a58)

3 - Partial fix for [GoogleMapsAddon#152](https://github.com/FlowingCode/GoogleMapsAddon/issues/152) issue, polygons not rendering after map initialization.  Added name to slot. Then slot assigment needs to be udpated on Flow part as well. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for assigning non-marker objects to the map via a named slot.
- **Enhancements**
  - Upgraded the default Google Maps API version to the latest release.
  - Updated map style configuration to accept arrays, ensuring better compatibility with Google Maps styling options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->